### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,27 @@
+name: Go CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: Install dependencies
+        run: go mod download
+      - name: Format
+        run: test -z "$(gofmt -s -d $(git ls-files '*.go'))"
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test -v ./...
+      - name: Test Coverage
+        run: |
+          go test -v -coverprofile=coverage.out ./...
+          go tool cover -func=coverage.out

--- a/README.md
+++ b/README.md
@@ -361,6 +361,10 @@ go test -v -race -coverprofile=coverage.out ./...
 go tool cover -html=coverage.out
 ```
 
+### Continuous Integration
+
+This repository includes a GitHub Actions workflow that automatically runs `go fmt`, `go vet`, and the test suite on every push and pull request.
+
 ## Contributing
 
 1. Fork the repository


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to lint, vet, and test the codebase
- document continuous integration in the README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687e7c93055c83258be7fc746a27d1c3